### PR TITLE
Changed to proper sequence of paramters in get()

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -27,7 +27,7 @@ mongoose.connect(uri, {
 app.use(bodyParser.json())
 
 // routes
-app.get("/", (res, req) => {
+app.get("/", (req, res) => {
   res.send("yay home page")
 })
 


### PR DESCRIPTION
Earlier, app.get("/", (res, req) => ..., was raising an error --> res.send() is not a function.